### PR TITLE
Add Sequelize models for e-commerce schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/models/category.js
+++ b/models/category.js
@@ -1,0 +1,21 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Category = sequelize.define('Category', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    slug: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  });
+
+  Category.associate = (models) => {
+    Category.hasMany(models.Product, { foreignKey: 'categoryId' });
+  };
+
+  return Category;
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,30 @@
+const { Sequelize } = require('sequelize');
+
+const sequelize = new Sequelize(
+  process.env.DB_NAME || 'shopdb',
+  process.env.DB_USER || 'root',
+  process.env.DB_PASSWORD || '',
+  {
+    host: process.env.DB_HOST || 'localhost',
+    dialect: 'mysql',
+    logging: false,
+  }
+);
+
+const db = {};
+
+db.sequelize = sequelize;
+
+db.Category = require('./category')(sequelize);
+db.Product = require('./product')(sequelize);
+db.User = require('./user')(sequelize);
+db.Order = require('./order')(sequelize);
+db.OrderItem = require('./orderItem')(sequelize);
+
+Object.keys(db).forEach((modelName) => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+module.exports = db;

--- a/models/order.js
+++ b/models/order.js
@@ -1,0 +1,30 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Order = sequelize.define('Order', {
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
+    },
+    total: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'paid', 'shipped', 'cancelled'),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
+  });
+
+  Order.associate = (models) => {
+    Order.belongsTo(models.User, { foreignKey: 'userId' });
+    Order.hasMany(models.OrderItem, { foreignKey: 'orderId' });
+  };
+
+  return Order;
+};

--- a/models/orderItem.js
+++ b/models/orderItem.js
@@ -1,0 +1,37 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const OrderItem = sequelize.define('OrderItem', {
+    orderId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Orders',
+        key: 'id',
+      },
+    },
+    productId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Products',
+        key: 'id',
+      },
+    },
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    price: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  });
+
+  OrderItem.associate = (models) => {
+    OrderItem.belongsTo(models.Order, { foreignKey: 'orderId' });
+    OrderItem.belongsTo(models.Product, { foreignKey: 'productId' });
+  };
+
+  return OrderItem;
+};

--- a/models/product.js
+++ b/models/product.js
@@ -1,0 +1,50 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Product = sequelize.define('Product', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    price: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      validate: {
+        min: 1,
+      },
+    },
+    stock: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    image: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    categoryId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Categories',
+        key: 'id',
+      },
+    },
+  });
+
+  Product.associate = (models) => {
+    Product.belongsTo(models.Category, { foreignKey: 'categoryId' });
+    Product.hasMany(models.OrderItem, { foreignKey: 'productId' });
+  };
+
+  return Product;
+};

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,40 @@
+const { DataTypes } = require('sequelize');
+const bcrypt = require('bcrypt');
+
+module.exports = (sequelize) => {
+  const User = sequelize.define('User', {
+    name: {
+      type: DataTypes.STRING,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+      },
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    role: {
+      type: DataTypes.ENUM('user', 'admin'),
+      allowNull: false,
+      defaultValue: 'user',
+    },
+  });
+
+  User.associate = (models) => {
+    User.hasMany(models.Order, { foreignKey: 'userId' });
+  };
+
+  User.beforeSave(async (user) => {
+    if (user.changed('password')) {
+      const salt = await bcrypt.genSalt(10);
+      user.password = await bcrypt.hash(user.password, salt);
+    }
+  });
+
+  return User;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "shop-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shop-api",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "shop-api",
+  "version": "1.0.0",
+  "description": "## Project Overview",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "sequelize": "^6.37.1",
+    "mysql2": "^3.9.7",
+    "bcrypt": "^5.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Sequelize models for Category, Product, User, Order, and OrderItem
- wire models together in `models/index.js`
- add basic project package.json with dependencies
- ignore node_modules and environment files

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882b58eb50c8321beddf2d0180dc8bb