### PR TITLE
Add ecommerce controllers

### DIFF
--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -1,0 +1,28 @@
+const db = require('../models');
+
+// Create a new category
+exports.createCategory = async (req, res, next) => {
+  try {
+    const { name, slug } = req.body;
+    if (!name) {
+      return res.status(400).json({ message: 'Name is required' });
+    }
+
+    const category = await db.Category.create({ name, slug });
+    res.status(201).json(category);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Get all categories including their related products
+exports.getCategoriesWithProducts = async (req, res, next) => {
+  try {
+    const categories = await db.Category.findAll({
+      include: [{ model: db.Product }],
+    });
+    res.json(categories);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -1,0 +1,103 @@
+const db = require('../models');
+const { Sequelize } = require('sequelize');
+
+// Place an order with transaction
+exports.placeOrder = async (req, res, next) => {
+  const transaction = await db.sequelize.transaction();
+  try {
+    const { userId, products } = req.body;
+    if (!userId || !Array.isArray(products) || !products.length) {
+      await transaction.rollback();
+      return res.status(400).json({ message: 'userId and products are required' });
+    }
+
+    let total = 0;
+    const orderItemsData = [];
+
+    for (const item of products) {
+      const product = await db.Product.findByPk(item.productId, { transaction, lock: transaction.LOCK.UPDATE });
+      if (!product) {
+        await transaction.rollback();
+        return res.status(404).json({ message: `Product ${item.productId} not found` });
+      }
+      if (product.stock < item.quantity) {
+        await transaction.rollback();
+        return res.status(400).json({ message: `Insufficient stock for product ${product.name}` });
+      }
+
+      total += product.price * item.quantity;
+      orderItemsData.push({ product, quantity: item.quantity });
+    }
+
+    const order = await db.Order.create({ userId, total }, { transaction });
+
+    for (const { product, quantity } of orderItemsData) {
+      await db.OrderItem.create({
+        orderId: order.id,
+        productId: product.id,
+        quantity,
+        price: product.price,
+      }, { transaction });
+
+      await product.update({ stock: product.stock - quantity }, { transaction });
+    }
+
+    await transaction.commit();
+
+    const createdOrder = await db.Order.findByPk(order.id, {
+      include: [{
+        model: db.OrderItem,
+        include: [db.Product],
+      }],
+    });
+
+    res.status(201).json(createdOrder);
+  } catch (err) {
+    await transaction.rollback();
+    next(err);
+  }
+};
+
+// Get all orders for the authenticated user
+exports.getOrdersForUser = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const orders = await db.Order.findAll({
+      where: { userId },
+      include: [{
+        model: db.OrderItem,
+        include: [db.Product],
+      }],
+      order: [['createdAt', 'DESC']],
+    });
+    res.json(orders);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Admin: update order status
+exports.updateOrderStatus = async (req, res, next) => {
+  try {
+    if (!req.user || req.user.role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const { id } = req.params;
+    const { status } = req.body;
+    const validStatuses = ['pending', 'paid', 'shipped', 'cancelled'];
+    if (!validStatuses.includes(status)) {
+      return res.status(400).json({ message: 'Invalid status' });
+    }
+
+    const order = await db.Order.findByPk(id);
+    if (!order) {
+      return res.status(404).json({ message: 'Order not found' });
+    }
+
+    await order.update({ status });
+    res.json(order);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -1,0 +1,96 @@
+const { Op } = require('sequelize');
+const db = require('../models');
+
+// Create a new product
+exports.createProduct = async (req, res, next) => {
+  try {
+    const { name, price, stock, image, categoryId } = req.body;
+    if (!name || !price || !categoryId) {
+      return res.status(400).json({ message: 'name, price and categoryId are required' });
+    }
+
+    const product = await db.Product.create({
+      name,
+      price,
+      stock,
+      image,
+      categoryId,
+    });
+
+    res.status(201).json(product);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Get all active products with pagination, filters and search
+exports.getProducts = async (req, res, next) => {
+  try {
+    const limit = parseInt(req.query.limit, 10) || 10;
+    const page = parseInt(req.query.page, 10) || 1;
+    const offset = (page - 1) * limit;
+    const where = { isActive: true };
+
+    if (req.query.categoryId) {
+      where.categoryId = req.query.categoryId;
+    }
+
+    if (req.query.minPrice || req.query.maxPrice) {
+      where.price = {};
+      if (req.query.minPrice) where.price[Op.gte] = req.query.minPrice;
+      if (req.query.maxPrice) where.price[Op.lte] = req.query.maxPrice;
+    }
+
+    if (req.query.search) {
+      where.name = { [Op.like]: `%${req.query.search}%` };
+    }
+
+    const { rows, count } = await db.Product.findAndCountAll({
+      where,
+      include: [{ model: db.Category }],
+      limit,
+      offset,
+    });
+
+    res.json({
+      products: rows,
+      total: count,
+      page,
+      pages: Math.ceil(count / limit),
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Update a product by id
+exports.updateProduct = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const product = await db.Product.findByPk(id);
+    if (!product) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+
+    await product.update(req.body);
+    res.json(product);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Delete a product by id
+exports.deleteProduct = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const product = await db.Product.findByPk(id);
+    if (!product) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+
+    await product.destroy();
+    res.json({ message: 'Product deleted' });
+  } catch (err) {
+    next(err);
+  }
+};


### PR DESCRIPTION
## Summary
- implement category creation and retrieval
- add product CRUD with filtering and pagination
- add order placement using transactions
- allow users to view orders and admins to update status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b6e88dd083219b9058a8b38d694f