### PR TITLE
Add e-commerce helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,68 @@ Below are sample prompts you can provide to Codex to generate this API backend. 
 
    > "Use multer to upload product images to the `uploads/` directory and store the file path on the product model."
 
+## ðŸ§° Codex Prompts â€“ E-Commerce Utilities & Helpers
+
+1. **Pagination Helper**
+
+   ```
+   Create a utility function for paginating Sequelize queries.
+
+   Input:
+   - req.query.page (default 1)
+   - req.query.limit (default 10)
+
+   Output:
+   - limit and offset values for Sequelize query
+   - currentPage and totalPages if totalCount is passed
+   ```
+
+2. **Error Handler Middleware**
+
+   ```
+   Create an Express error handling middleware.
+
+   Behavior:
+   - Catches any thrown errors
+   - Logs the error to console
+   - Sends a response with status 500 and JSON: { message: "Internal Server Error" }
+   - If the error has a 'statusCode' or 'message' property, use them instead
+   ```
+
+3. **JWT Authentication Middleware**
+
+   ```
+   Create Express middleware to authenticate users using JWT.
+
+   Steps:
+   - Read token from Authorization header
+   - Verify the token using jsonwebtoken
+   - Attach user info to req.user
+   - Return 401 if token is missing or invalid
+   ```
+
+4. **Admin-Only Middleware**
+
+   ```
+   Create an Express middleware that allows access only to admin users.
+
+   Behavior:
+   - Check if req.user.role is 'admin'
+   - If not, respond with 403 Forbidden
+   ```
+
+5. **Multer Upload Config**
+
+   ```
+   Create a Multer configuration to handle single file upload.
+
+   Behavior:
+   - Accepts only image files (jpg, jpeg, png)
+   - Stores them in the /uploads directory
+   - Saves original filename or generates a unique one
+   - Limits file size to 2MB
+   ```
+
 ## Final Notes
 
 This README acts as both a business and technical reference for the project. With these requirements and prompts, Codex can generate a full backend system implementing authentication, product management, order handling, and more.

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const categoryRoutes = require('./routes/categories');
 const productRoutes = require('./routes/products');
 const authRoutes = require('./routes/auth');
 const orderRoutes = require('./routes/orders');
+const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
 
@@ -14,6 +15,7 @@ app.use('/categories', categoryRoutes);
 app.use('/products', productRoutes);
 app.use('/auth', authRoutes);
 app.use('/orders', orderRoutes);
+app.use(errorHandler);
 
 const start = async () => {
   try {

--- a/middleware/adminOnly.js
+++ b/middleware/adminOnly.js
@@ -1,0 +1,6 @@
+module.exports = (req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    return next();
+  }
+  return res.status(403).json({ message: 'Forbidden' });
+};

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+module.exports = (err, req, res, next) => {
+  console.error(err);
+  const status = err.statusCode || 500;
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ message });
+};

--- a/middleware/jwtAuth.js
+++ b/middleware/jwtAuth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const token = header.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+};

--- a/middleware/upload.js
+++ b/middleware/upload.js
@@ -1,0 +1,33 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const uploadDir = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (req, file, cb) => {
+    const uniqueName = `${Date.now()}-${file.originalname}`;
+    cb(null, uniqueName);
+  },
+});
+
+const fileFilter = (req, file, cb) => {
+  const ext = path.extname(file.originalname).toLowerCase();
+  if (ext === '.jpg' || ext === '.jpeg' || ext === '.png') {
+    cb(null, true);
+  } else {
+    cb(new Error('Only images are allowed'));
+  }
+};
+
+module.exports = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 2 * 1024 * 1024 },
+}).single('file');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mysql2": "^3.9.7",
     "bcrypt": "^5.1.1",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.1"
+    "jsonwebtoken": "^9.0.1",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,0 +1,13 @@
+function paginate(req, totalCount) {
+  const page = parseInt(req.query.page, 10) || 1;
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = (page - 1) * limit;
+  const result = { limit, offset };
+  if (typeof totalCount === 'number') {
+    result.currentPage = page;
+    result.totalPages = Math.ceil(totalCount / limit);
+  }
+  return result;
+}
+
+module.exports = paginate;


### PR DESCRIPTION
## Summary
- document Codex prompts for helper utilities and middleware
- add pagination helper in `utils`
- implement error handler middleware and use it in `app.js`
- add JWT auth and admin-only middleware
- configure multer upload middleware
- create uploads folder with placeholder
- install multer in package.json

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882b9fdcb7c83219d5c115f4a339763