### PR TITLE
Setup Swagger and env config

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,8 @@
+require('dotenv').config();
 const express = require('express');
+const cors = require('cors');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./config/swagger');
 const db = require('./models');
 
 const categoryRoutes = require('./routes/categories');
@@ -10,6 +14,8 @@ const errorHandler = require('./middleware/errorHandler');
 const app = express();
 
 app.use(express.json());
+app.use(cors());
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/categories', categoryRoutes);
 app.use('/products', productRoutes);
@@ -19,9 +25,11 @@ app.use(errorHandler);
 
 const start = async () => {
   try {
+    await db.sequelize.authenticate();
+    console.log('DB connected');
     await db.sequelize.sync();
     app.listen(3000, () => {
-      console.log('Server listening on port 3000');
+      console.log('Server running at port 3000');
     });
   } catch (err) {
     console.error('Unable to start server:', err);

--- a/config/db.config.js
+++ b/config/db.config.js
@@ -1,0 +1,9 @@
+require('dotenv').config();
+
+module.exports = {
+  HOST: process.env.DB_HOST || 'localhost',
+  USER: process.env.DB_USER || 'root',
+  PASSWORD: process.env.DB_PASS || '',
+  DB: process.env.DB_NAME || 'shopdb',
+  dialect: 'mysql',
+};

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -1,0 +1,20 @@
+const swaggerJSDoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Shop API',
+      version: '1.0.0',
+      description: 'API documentation for the Shop application',
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+      },
+    ],
+  },
+  apis: ['./routes/*.js'],
+};
+
+module.exports = swaggerJSDoc(options);

--- a/models/index.js
+++ b/models/index.js
@@ -1,12 +1,13 @@
 const { Sequelize } = require('sequelize');
+const dbConfig = require('../config/db.config');
 
 const sequelize = new Sequelize(
-  process.env.DB_NAME || 'shopdb',
-  process.env.DB_USER || 'root',
-  process.env.DB_PASSWORD || '',
+  dbConfig.DB,
+  dbConfig.USER,
+  dbConfig.PASSWORD,
   {
-    host: process.env.DB_HOST || 'localhost',
-    dialect: 'mysql',
+    host: dbConfig.HOST,
+    dialect: dbConfig.dialect,
     logging: false,
   }
 );

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "## Project Overview",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "nodemon app.js",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +17,13 @@
     "bcrypt": "^5.1.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.1",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.2.3"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- wire up dotenv, cors, and swagger middleware in `app.js`
- add Sequelize env-based configuration
- generate Swagger specification in `config/swagger.js`
- update Sequelize initialization to use new config
- add development scripts and needed dependencies

## Testing
- `npm run start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6882c105e5dc83218fa54961e38e4fb1