### PR TITLE
Add Docker support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+DB_HOST=db
+DB_USER=root
+DB_PASS=root
+DB_NAME=shop_db
+JWT_SECRET=your_jwt_secret
+PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/config/db.config.js
+++ b/config/db.config.js
@@ -4,6 +4,6 @@ module.exports = {
   HOST: process.env.DB_HOST || 'localhost',
   USER: process.env.DB_USER || 'root',
   PASSWORD: process.env.DB_PASS || '',
-  DB: process.env.DB_NAME || 'shopdb',
+  DB: process.env.DB_NAME || 'shop_db',
   dialect: 'mysql',
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+      - /app/node_modules
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: shop_db
+    ports:
+      - "3306:3306"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon app.js",
-    "start": "node app.js"
+    "dev": "nodemon src/app.js",
+    "start": "node src/app.js"
   },
   "keywords": [],
   "author": "",

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,2 @@
+// Entry point used by Docker and npm scripts
+require('../app');


### PR DESCRIPTION
## Summary
- add Dockerfile for Node.js 18 image
- configure docker-compose with app and MySQL services
- provide default environment configuration
- adjust Sequelize config defaults
- update npm scripts and provide new src entrypoint

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882cc1ba40c8321938f67c7bff0eb05